### PR TITLE
add elements prop to hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ function PaymentForm() {
 }
 
 function Form() {
-    const stripe = useStripe()
+    const { stripe, elements } = useStripe()
 
     const [formState, setFormState] = useState({
         name: '',
@@ -37,6 +37,12 @@ function Form() {
         event.preventDefault()
 
         const paymentMethod = {
+            payment_method: {
+                card: elements.getElement('card'),
+                billing_details: {
+                    name: 'Jenny Rosen',
+                },
+            },
             payment_method_data: {
                 billing_details: {
                     name: formState.name,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-stripe-hooks",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-stripe-hooks",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "React hooks for Stripe.js and Stripe Elements",
     "main": "dist/index.js",
     "module": "dist/index.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ const Context = createContext()
 
 const useStripe = () => useContext(Context)
 
-const HookProvider = ({ children, stripe }) => (
-    <Context.Provider value={stripe}>
+const HookProvider = ({ children, stripe, elements }) => (
+    <Context.Provider value={{ stripe, elements }}>
         {children}
     </Context.Provider>
 )


### PR DESCRIPTION
Thanks for this package, the hook syntax is much nicer!
In my case, I needed to use the `elements` prop provided by `injectStripe` to retrieve the card form inputs (see [this tutorial](https://stripe.com/docs/payments/accept-a-payment#web-submit-payment)).

I achieved this by providing an object containing both `stripe` and `elements` objects in the hook, instead of directly the `stripe` object content.
This is a breaking change: need to replace `const stripe = useStripe()` by `const { stripe } = useStripe()`.
But I thought this was better than adding a second hook.